### PR TITLE
Add .gitattributes for Solidity syntax highlighting on Github.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
I learned about this from [your Contracts repo](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/.gitattributes). You can see a [working example here](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/ownership/Ownable.sol).